### PR TITLE
Update 6TEI_GP_epilogue.xml

### DIFF
--- a/6TEI_GP_epilogue.xml
+++ b/6TEI_GP_epilogue.xml
@@ -177,7 +177,7 @@
                         Ego Euthymum adibo, 
                         quem Gallis suis domi male consulere habeo compertum, 
                         ut Philonicus quoque male Gallinis consulit. 
-                        <app><lem wit="#Zimmel">Utrimque</lem><rdg wit="#ed">Utrinque</rdg></app> enim deplumantur iam, &amp; ad Culinam destinantur, laetitiam facturi avidis faucibus. 
+                        <app><lem wit="#Zimmel">Utrimque</lem><rdg wit="#ed">Utrinque</rdg></app> enim de plumantur iam, &amp; ad Culinam destinantur, laetitiam facturi avidis faucibus. 
                         Illic ego viscera distendam, &amp; ut me pinguiorem Giggulirus faciat curabo. 
                         Bibamque adeo, 
                         ut Veternosum me tota familia putet. 


### PR DESCRIPTION
Il s'agit d'une invention de l'auteur. Le verbe "deplumor" n'existe pas et "deplumo" non plus. Par contre, le verbe "plumo" lui existe et signifie "couvrir de plumes". Pour la traduction du néologisme, je pencherais pour "ne plus être recouvert de plumes" ou le sens transparent de "être déplumé"